### PR TITLE
Migrate money commands to use ConfigManager

### DIFF
--- a/.claude/commands/money/money-integrations.md
+++ b/.claude/commands/money/money-integrations.md
@@ -18,10 +18,53 @@ Comprehensive financial integration management system for API connections, data 
 You are a financial integration specialist focused on maintaining secure, reliable connections to financial platforms while optimizing data quality and automation efficiency. When this command is invoked:
 
 1. **Integration Management Framework**:
-   - Load integration configuration from `integrations.yaml`
+   - Use ConfigManager to load financial tool configurations with type-safe access and validation
    - Monitor connection health and data synchronization status
    - Assess security compliance and credential management
    - Provide optimization recommendations for reliability and efficiency
+
+**ConfigManager Integration Example**:
+```python
+from tools import ConfigManager
+from tools.schemas import IntegrationsConfig, FinancialTool
+
+# Initialize ConfigManager
+mgr = ConfigManager()
+
+# Load all financial tools with type safety
+all_tools = mgr.get_all_financial_tools()
+
+# Filter for active tools only
+active_tools = mgr.get_all_financial_tools(filters={"enabled": [True]})
+
+# Get specific financial tool
+plaid = mgr.get_financial_tool("plaid")
+print(f"Provider: {plaid.provider}")
+print(f"Status: {plaid.status}")
+print(f"Sync Frequency: {plaid.sync_frequency}")
+
+# Access nested configuration safely
+if plaid.rate_limits:
+    print(f"Rate Limits: {plaid.rate_limits.requests_per_hour}/hour")
+
+# Iterate through all tools
+for tool_id, tool in all_tools.items():
+    print(f"{tool_id}: {tool.provider} - {tool.status}")
+    for data_type in tool.data_types:
+        print(f"  - {data_type}")
+```
+
+**Error Handling**:
+```python
+from tools.exceptions import ConfigNotFoundError, ConfigValidationError
+
+try:
+    tool = mgr.get_financial_tool("unknown_tool")
+except KeyError:
+    print("Financial tool not found in integrations.yaml")
+except ConfigValidationError as e:
+    print(f"Invalid tool configuration: {e}")
+```
 
 2. **Integration Analysis Process**:
    - **Connection Health**: Real-time status monitoring and issue identification
@@ -477,3 +520,18 @@ You are a financial integration specialist focused on maintaining secure, reliab
 - Data conflicts: Validation rules and manual review triggers
 
 Focus on maintaining secure, reliable financial integrations that provide comprehensive data coverage while optimizing for performance, security, and automation efficiency.
+
+## ConfigManager Benefits
+
+**Type Safety**: FinancialTool model prevents runtime errors with validated field types
+**Automatic Validation**: Pydantic validates configuration structure and data types
+**Caching**: <10ms cached reads for repeated access to financial tool configurations
+**Secure Credentials**: Never store credentials in config - use environment variables
+**Error Messages**: Clear validation errors for malformed financial tool configurations
+
+**Best Practices**:
+- Use `mgr.get_all_financial_tools(filters={"enabled": [True]})` for active tools
+- Access credentials via environment variables (PLAID_CLIENT_ID, etc.)
+- Use type-safe field access: `tool.provider`, `tool.status`, `tool.sync_frequency`
+- Handle KeyError for missing financial tools gracefully
+- Use ConfigValidationError to catch configuration issues early

--- a/.claude/commands/money/money-profile.md
+++ b/.claude/commands/money/money-profile.md
@@ -20,8 +20,24 @@ You are a financial planning specialist focused on maintaining accurate, compreh
 1. **Financial Profile Management**:
    - Load current financial profile from `financial_profile.yaml`
    - Integrate account data from `accounts.yaml` and platform connections
+   - Use ConfigManager for type-safe access to financial tool integrations (see `/money integrations`)
    - Validate profile consistency and identify update needs
    - Suggest profile improvements based on financial progression
+
+**Financial Tools Integration**:
+```python
+from tools import ConfigManager
+
+mgr = ConfigManager()
+
+# Get financial platform connections for profile integration
+active_tools = mgr.get_all_financial_tools(filters={"enabled": [True]})
+for tool_id, tool in active_tools.items():
+    if tool.last_sync:
+        print(f"{tool.provider}: Last synced {tool.last_sync}")
+```
+
+**Note**: Full ConfigManager integration for financial_profile.yaml and accounts.yaml will be added once those configuration files are created with proper schemas.
 
 2. **Financial Analysis Framework**:
    - **Goal Assessment**: Progress tracking and timeline analysis

--- a/.claude/integrations.yaml
+++ b/.claude/integrations.yaml
@@ -204,6 +204,76 @@ integrations:
       required_directories: [".claude/commands/decide"]
       sync_dependencies: ["team_management", "projects", "notes"]
 
+# Financial Platform Integrations
+financial_tools:
+  plaid:
+    enabled: true
+    provider: "Plaid"
+    connection_type: "API"
+    api_version: "2020-09-14"
+    credentials:
+      # Use environment variables for sensitive data
+      client_id: null  # Set via PLAID_CLIENT_ID
+      client_secret: null  # Set via PLAID_CLIENT_SECRET
+      access_token: null
+    sync_frequency: "daily"
+    sync_time: "06:00"
+    data_types:
+      - balances
+      - transactions
+      - account_info
+    rate_limits:
+      requests_per_hour: 100
+      requests_per_day: 1000
+    status: "active"
+    last_sync: null
+    sync_errors: 0
+    notes: "Primary banking aggregation service"
+
+  vanguard:
+    enabled: true
+    provider: "Vanguard"
+    connection_type: "API"
+    credentials:
+      username: null  # Set via VANGUARD_USERNAME
+      password: null  # Set via VANGUARD_PASSWORD
+      api_key: null
+    sync_frequency: "daily"
+    sync_time: "06:00"
+    data_types:
+      - holdings
+      - performance
+      - transactions
+      - dividends
+    status: "active"
+    last_sync: null
+    sync_errors: 0
+    notes: "Roth IRA investment tracking"
+
+  schwab:
+    enabled: true
+    provider: "Charles Schwab"
+    connection_type: "API"
+    api_version: "v2"
+    credentials:
+      client_id: null  # Set via SCHWAB_CLIENT_ID
+      client_secret: null  # Set via SCHWAB_CLIENT_SECRET
+      access_token: null
+      refresh_token: null
+    sync_frequency: "daily"
+    sync_time: "06:00"
+    data_types:
+      - positions
+      - market_data
+      - trading_history
+    rate_limits:
+      requests_per_hour: 120
+      requests_per_day: 1200
+    status: "active"
+    last_sync: null
+    sync_errors: 0
+    notes: "Taxable brokerage account"
+
 # Integration Categories
 categories:
   version_control:

--- a/test_financial_tools.py
+++ b/test_financial_tools.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Test financial tool configuration loading with ConfigManager.
+
+This script validates the financial_tools section migration to ConfigManager.
+"""
+
+import sys
+from pathlib import Path
+
+# Add tools directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tools import ConfigManager
+from tools.schemas import IntegrationsConfig, FinancialTool
+from tools.config_manager import ConfigValidationError
+
+
+def test_financial_tools():
+    """Test financial tool configuration loading."""
+    print("=" * 60)
+    print("Testing Financial Tools ConfigManager Integration")
+    print("=" * 60)
+
+    mgr = ConfigManager()
+
+    # Test 1: Load all financial tools
+    print("\n✅ Test 1: Load all financial tools")
+    try:
+        all_tools = mgr.get_all_financial_tools()
+        print(f"Loaded {len(all_tools)} financial tools:")
+        for tool_id, tool in all_tools.items():
+            print(f"  - {tool_id}: {tool.provider} ({tool.status})")
+    except Exception as e:
+        print(f"❌ Failed to load financial tools: {e}")
+        return False
+
+    # Test 2: Get specific financial tool
+    print("\n✅ Test 2: Get specific financial tool (plaid)")
+    try:
+        plaid = mgr.get_financial_tool("plaid")
+        print(f"Provider: {plaid.provider}")
+        print(f"Status: {plaid.status}")
+        print(f"Connection Type: {plaid.connection_type}")
+        print(f"Sync Frequency: {plaid.sync_frequency}")
+        print(f"Data Types: {', '.join(plaid.data_types)}")
+        if plaid.rate_limits:
+            print(f"Rate Limits: {plaid.rate_limits.requests_per_hour}/hour, {plaid.rate_limits.requests_per_day}/day")
+    except Exception as e:
+        print(f"❌ Failed to get plaid: {e}")
+        return False
+
+    # Test 3: Filter for active tools
+    print("\n✅ Test 3: Filter for active financial tools")
+    try:
+        active_tools = mgr.get_all_financial_tools(filters={"enabled": [True]})
+        print(f"Found {len(active_tools)} active financial tools:")
+        for tool_id, tool in active_tools.items():
+            print(f"  - {tool_id}: {tool.provider}")
+    except Exception as e:
+        print(f"❌ Failed to filter active tools: {e}")
+        return False
+
+    # Test 4: Test error handling for missing tool
+    print("\n✅ Test 4: Test error handling for missing tool")
+    try:
+        mgr.get_financial_tool("nonexistent_tool")
+        print("❌ Should have raised KeyError for missing tool")
+        return False
+    except KeyError as e:
+        print(f"✅ Correctly raised KeyError: {e}")
+
+    # Test 5: Access nested configuration
+    print("\n✅ Test 5: Access nested configuration safely")
+    try:
+        schwab = mgr.get_financial_tool("schwab")
+        print(f"Schwab Provider: {schwab.provider}")
+        print(f"API Version: {schwab.api_version}")
+        if schwab.credentials:
+            print("Credentials structure exists (values should be null/env vars)")
+            print(f"  - client_id: {schwab.credentials.client_id}")
+            print(f"  - client_secret: {schwab.credentials.client_secret}")
+        if schwab.rate_limits:
+            print(f"Rate Limits: {schwab.rate_limits.requests_per_hour}/hour")
+    except Exception as e:
+        print(f"❌ Failed to access nested config: {e}")
+        return False
+
+    # Test 6: Validate all tools have required fields
+    print("\n✅ Test 6: Validate required fields for all tools")
+    try:
+        for tool_id, tool in all_tools.items():
+            assert tool.enabled is not None, f"{tool_id}: enabled is required"
+            assert tool.provider, f"{tool_id}: provider is required"
+            assert tool.connection_type, f"{tool_id}: connection_type is required"
+            assert tool.credentials, f"{tool_id}: credentials is required"
+            assert tool.sync_frequency, f"{tool_id}: sync_frequency is required"
+            assert tool.status, f"{tool_id}: status is required"
+            assert isinstance(tool.data_types, list), f"{tool_id}: data_types must be a list"
+        print("✅ All financial tools have required fields")
+    except AssertionError as e:
+        print(f"❌ Validation failed: {e}")
+        return False
+
+    print("\n" + "=" * 60)
+    print("✅ All tests passed!")
+    print("=" * 60)
+    return True
+
+
+if __name__ == "__main__":
+    success = test_financial_tools()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- Migrated `/money:money-integrations` command to use ConfigManager
- Added financial_tools section to integrations.yaml
- Added ConfigManager methods for financial tool access
- Partial integration for `/money:money-profile` (full integration pending financial_profile.yaml creation)

## Changes

### Configuration Updates
- Added `financial_tools` section to `.claude/integrations.yaml`
- Configured Plaid, Vanguard, and Schwab integrations with proper schemas
- Set up credential structure for environment variable usage

### ConfigManager Methods
```python
mgr.get_financial_tool(tool_id)  # Get single tool
mgr.get_all_financial_tools(filters)  # Get all with optional filtering
mgr.update_financial_tool(tool_id, updates)  # Update tool configuration
```

### Command Documentation
- Updated money-integrations.md with ConfigManager examples
- Added type-safe access patterns and error handling
- Documented secure credential management practices
- Added money-profile.md integration note

### Testing
Comprehensive test suite validates:
- ✅ All 3 financial tools load correctly
- ✅ Type-safe field access
- ✅ Filtering and error handling
- ✅ Required field validation
- ✅ Nested configuration access

## Benefits
- **Type Safety**: FinancialTool Pydantic model prevents runtime errors
- **Validation**: Automatic configuration structure validation
- **Caching**: <10ms cached reads for repeated access
- **Security**: Environment variable guidance for credentials
- **Error Messages**: Clear validation errors

## Related Issues
Fixes #128
Part of #108 (ConfigManager Migration Initiative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)